### PR TITLE
Add TTL-aware caching for robots and DNS lookups

### DIFF
--- a/netlify/functions/lib/robots.ts
+++ b/netlify/functions/lib/robots.ts
@@ -1,15 +1,50 @@
+interface CacheEntry<T> { value: T; expires: number }
+const ROBOTS_CACHE = new Map<string, CacheEntry<string>>();
+const ROBOTS_CACHE_TTL_MS = parseInt(process.env.ROBOTS_CACHE_TTL_MS || '3600000', 10);
+const ROBOTS_CACHE_MAX = parseInt(process.env.ROBOTS_CACHE_MAX || '100', 10);
+const REQUEST_TIMEOUT_MS = parseInt(process.env.REQUEST_TIMEOUT_MS || '15000', 10);
+const ROBOTS_FETCH_RETRIES = parseInt(process.env.ROBOTS_FETCH_RETRIES || '3', 10);
+
+function purgeExpired<T>(cache: Map<string, CacheEntry<T>>, now: number): void {
+  for (const [k, v] of cache) if (v.expires <= now) cache.delete(k);
+}
+
+async function fetchWithRetry(url: string, init: RequestInit, retries = ROBOTS_FETCH_RETRIES): Promise<Response> {
+  let lastErr: unknown;
+  for (let i = 0; i < retries; i++) {
+    const controller = new AbortController();
+    const t = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
+    try {
+      const res = await fetch(url, { ...init, signal: controller.signal });
+      clearTimeout(t);
+      return res;
+    } catch (err) {
+      clearTimeout(t);
+      lastErr = err;
+      if (i === retries - 1) throw err;
+    }
+  }
+  throw lastErr as Error;
+}
+
 export async function isAllowedByRobots(url: string, userAgent: string): Promise<boolean> {
   try {
     const u = new URL(url);
     const robotsUrl = `${u.origin}/robots.txt`;
-    const controller = new AbortController();
-    const t = setTimeout(() => controller.abort(), parseInt(process.env.REQUEST_TIMEOUT_MS || '15000', 10));
-    const res = await fetch(robotsUrl, { redirect: 'follow', headers: { 'User-Agent': userAgent }, signal: controller.signal });
-    clearTimeout(t);
-    if (!res.ok) return true;
-    const text = await res.text();
+    const now = Date.now();
+    purgeExpired(ROBOTS_CACHE, now);
+    let text = ROBOTS_CACHE.get(robotsUrl)?.value;
+    if (!text) {
+      const res = await fetchWithRetry(robotsUrl, { redirect: 'follow', headers: { 'User-Agent': userAgent } });
+      if (!res.ok) return true;
+      text = await res.text();
+      if (ROBOTS_CACHE.size >= ROBOTS_CACHE_MAX) ROBOTS_CACHE.delete(ROBOTS_CACHE.keys().next().value);
+      ROBOTS_CACHE.set(robotsUrl, { value: text, expires: now + ROBOTS_CACHE_TTL_MS });
+    }
     return parseRobots(text, userAgent, u.pathname);
-  } catch { return true; }
+  } catch {
+    return true;
+  }
 }
 function parseRobots(content: string, ua: string, path: string): boolean {
   const lines = content.split(/\r?\n/);

--- a/netlify/functions/lib/ssrf.ts
+++ b/netlify/functions/lib/ssrf.ts
@@ -1,5 +1,6 @@
 import dns from 'node:dns/promises';
 import net from 'node:net';
+import type { LookupAddress } from 'node:dns';
 
 const PRIVATE_V4 = [
   ['10.0.0.0', '10.255.255.255'],
@@ -16,6 +17,35 @@ function isPrivateV6(addr: string): boolean {
   return x==='::1' || x.startsWith('fe80:') || x.startsWith('fc') || x.startsWith('fd');
 }
 
+interface CacheEntry<T> { value: T; expires: number }
+const DNS_CACHE = new Map<string, CacheEntry<LookupAddress[]>>();
+const DNS_CACHE_TTL_MS = parseInt(process.env.DNS_CACHE_TTL_MS || '3600000', 10);
+const DNS_CACHE_MAX = parseInt(process.env.DNS_CACHE_MAX || '100', 10);
+const DNS_TIMEOUT_MS = parseInt(process.env.DNS_TIMEOUT_MS || '5000', 10);
+const DNS_LOOKUP_RETRIES = parseInt(process.env.DNS_LOOKUP_RETRIES || '3', 10);
+
+function purgeExpired<T>(cache: Map<string, CacheEntry<T>>, now: number): void {
+  for (const [k, v] of cache) if (v.expires <= now) cache.delete(k);
+}
+
+async function lookupWithRetry(host: string): Promise<LookupAddress[]> {
+  let lastErr: unknown;
+  for (let i = 0; i < DNS_LOOKUP_RETRIES; i++) {
+    const controller = new AbortController();
+    const t = setTimeout(() => controller.abort(), DNS_TIMEOUT_MS);
+    try {
+      const res = await dns.lookup(host, { all: true, signal: controller.signal });
+      clearTimeout(t);
+      return res;
+    } catch (err) {
+      clearTimeout(t);
+      lastErr = err;
+      if (i === DNS_LOOKUP_RETRIES - 1) throw err;
+    }
+  }
+  throw lastErr as Error;
+}
+
 export async function assertUrlIsSafe(input: string): Promise<void> {
   let u: URL;
   try { u = new URL(input); } catch { throw new Error('Invalid URL'); }
@@ -24,7 +54,14 @@ export async function assertUrlIsSafe(input: string): Promise<void> {
   const host = u.hostname.toLowerCase();
   if (host === 'localhost' || host.endsWith('.local')) throw new Error('Local host blocked');
 
-  const recs = await dns.lookup(host, { all: true });
+  const now = Date.now();
+  purgeExpired(DNS_CACHE, now);
+  let recs = DNS_CACHE.get(host)?.value;
+  if (!recs) {
+    recs = await lookupWithRetry(host);
+    if (DNS_CACHE.size >= DNS_CACHE_MAX) DNS_CACHE.delete(DNS_CACHE.keys().next().value);
+    DNS_CACHE.set(host, { value: recs, expires: now + DNS_CACHE_TTL_MS });
+  }
   for (const r of recs) {
     if (net.isIP(r.address) === 4 && isPrivateV4(r.address)) throw new Error('Private IPv4 blocked');
     if (net.isIP(r.address) === 6 && isPrivateV6(r.address)) throw new Error('Private IPv6 blocked');


### PR DESCRIPTION
## Summary
- add expiring, size-limited cache around robots.txt fetches
- cache DNS lookups with TTL and size limit to strengthen SSRF protection
- add retry and timeout helpers for network calls

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b89eeee7b4832b81e4617a5228962c