### PR TITLE
Exclude jsdom from Netlify function bundling

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -5,6 +5,7 @@
 [functions]
   directory = "netlify/functions"
   node_bundler = "esbuild"
+  external_node_modules = ["jsdom"]
   included_files = []
 
 # Route clean /api/* to the single API function


### PR DESCRIPTION
## Summary
- prevent esbuild from bundling jsdom by adding `external_node_modules` to `netlify.toml`

## Testing
- `npx netlify build --offline`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b8c0d101cc832ba4f84286eed56e81